### PR TITLE
set up CI for 8.14 with testing

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,15 +1,12 @@
-name: CI
+name: Docker CI
 
 on:
   push:
     branches:
-      - master
+      - v8.14
   pull_request:
     branches:
       - '**'
-  schedule:
-    # test master every day at 04:00 UTC
-      - cron: '0 4 * * *'
 
 jobs:
   build:
@@ -18,7 +15,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.14'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Follow the instructions on https://github.com/coq-community/templates to regener
 This Coq library provides BigN, BigZ, and BigQ that used to
 be part of the standard library.
 
-
 ## Meta
 
 - Author(s):
@@ -36,6 +35,8 @@ be part of the standard library.
   - Evgeny Makarov
   - Pierre Letouzey
 - Coq-community maintainer(s):
+  - Pierre Roux ([**@proux01**](https://github.com/proux01))
+  - Érik Martin-Dorel ([**@erikmd**](https://github.com/erikmd))
 - License: [GNU Lesser General Public License v2.1](LICENSE)
 - Compatible Coq versions: The v8.14 branch tracks version 8.14 of Coq, see releases for compatibility with released versions of Coq
 - Compatible OCaml versions: all versions supported by Coq

--- a/coq-bignums.opam
+++ b/coq-bignums.opam
@@ -1,8 +1,5 @@
-# This file was generated from `meta.yml`, please do not edit manually.
-# Follow the instructions on https://github.com/coq-community/templates to regenerate.
-
 opam-version: "2.0"
-maintainer: "Laurent.Thery@inria.fr"
+maintainer: "palmskog@gmail.com"
 version: "8.14.dev"
 
 homepage: "https://github.com/coq-community/bignums"
@@ -13,10 +10,10 @@ license: "LGPL-2.1-only"
 synopsis: "Bignums, the Coq library of arbitrary large numbers"
 description: """
 This Coq library provides BigN, BigZ, and BigQ that used to
-be part of the standard library.
-"""
+be part of the standard library."""
 
 build: [make "-j%{jobs}%"]
+run-test: [make "-C" "tests" "-j%{jobs}%"]
 install: [make "install"]
 depends: [
   "ocaml" 

--- a/meta.yml
+++ b/meta.yml
@@ -8,7 +8,7 @@ branch: 'v8.14'
 
 synopsis: >-
   Bignums, the Coq library of arbitrary large numbers
-description: |
+description: |-
   This Coq library provides BigN, BigZ, and BigQ that used to
   be part of the standard library.
 
@@ -19,7 +19,13 @@ authors:
 - name: Evgeny Makarov
 - name: Pierre Letouzey
 
-opam-file-maintainer: Laurent.Thery@inria.fr
+maintainers:
+- name: Pierre Roux
+  nickname: proux01
+- name: Érik Martin-Dorel
+  nickname: erikmd
+
+opam-file-maintainer: palmskog@gmail.com
 
 opam-file-version: '8.14.dev'
 


### PR DESCRIPTION
It's a bit tricky to set up all boilerplate in a plugin branch with CI, if one needs to include things like running tests. I do some slight overriding of the templates to do this. Will try to extend templates upstream at some point, but better to have CI here in the meantime.