### PR TITLE
fix CI and some boilerplate for 8.15

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,15 +1,12 @@
-name: CI
+name: Docker CI
 
 on:
   push:
     branches:
-      - master
+      - v8.15
   pull_request:
     branches:
       - '**'
-  schedule:
-    # test master every day at 04:00 UTC
-      - cron: '0 4 * * *'
 
 jobs:
   build:
@@ -18,7 +15,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.15'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ BigN/NMake_gen.v
 *.vo
 *.glob
 *.aux
+*.a
+*.cmxa
 *~
 Makefile.coq
 Makefile.coq.conf
@@ -17,3 +19,5 @@ Makefile.coq.conf
 *.vos
 *.vok
 *.out.real
+.lia.cache
+.nia.cache

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ be part of the standard library.
   - Evgeny Makarov
   - Pierre Letouzey
 - Coq-community maintainer(s):
+  - Pierre Roux ([**@proux01**](https://github.com/proux01))
+  - Érik Martin-Dorel ([**@erikmd**](https://github.com/erikmd))
 - License: [GNU Lesser General Public License v2.1](LICENSE)
 - Compatible Coq versions: The v8.15 branch tracks version 8.15 of Coq, see releases for compatibility with released versions of Coq
 - Compatible OCaml versions: all versions supported by Coq

--- a/coq-bignums.opam
+++ b/coq-bignums.opam
@@ -2,7 +2,7 @@
 # Follow the instructions on https://github.com/coq-community/templates to regenerate.
 
 opam-version: "2.0"
-maintainer: "Laurent.Thery@inria.fr"
+maintainer: "palmskog@gmail.com"
 version: "8.15.dev"
 
 homepage: "https://github.com/coq-community/bignums"
@@ -10,7 +10,7 @@ dev-repo: "git+https://github.com/coq-community/bignums.git"
 bug-reports: "https://github.com/coq-community/bignums/issues"
 license: "LGPL-2.1-only"
 
-synopsis: "Bignums, the Coq library of arbitrary large numbers"
+synopsis: "Bignums, the Coq library of arbitrarily large numbers"
 description: """
 This Coq library provides BigN, BigZ, and BigQ that used to
 be part of the standard library.
@@ -30,7 +30,7 @@ tags: [
   "keyword:integer numbers"
   "keyword:rational numbers"
   "keyword:arithmetic"
-  "keyword:arbitrary-precision"
+  "keyword:arbitrary precision"
   "logpath:Bignums"
 ]
 authors: [

--- a/meta.yml
+++ b/meta.yml
@@ -7,7 +7,8 @@ action: true
 branch: 'v8.15'
 
 synopsis: >-
-  Bignums, the Coq library of arbitrary large numbers
+  Bignums, the Coq library of arbitrarily large numbers
+
 description: |
   This Coq library provides BigN, BigZ, and BigQ that used to
   be part of the standard library.
@@ -19,7 +20,13 @@ authors:
 - name: Evgeny Makarov
 - name: Pierre Letouzey
 
-opam-file-maintainer: Laurent.Thery@inria.fr
+maintainers:
+- name: Pierre Roux
+  nickname: proux01
+- name: Érik Martin-Dorel
+  nickname: erikmd
+
+opam-file-maintainer: palmskog@gmail.com
 
 opam-file-version: '8.15.dev'
 
@@ -47,7 +54,7 @@ keywords:
 - name: integer numbers
 - name: rational numbers
 - name: arithmetic
-- name: arbitrary-precision
+- name: arbitrary precision
 
 categories:
 - name: Miscellaneous/Coq Extensions


### PR DESCRIPTION
Since we may have to do some update for 8.15, here is proper CI and updated boilerplate for the `v8.15` branch.