### PR TITLE
Change notations [_] to `[_]

### DIFF
--- a/BigN/BigN.v
+++ b/BigN/BigN.v
@@ -67,7 +67,7 @@ Notation "x < y < z" := (x<y /\ y<z) : bigN_scope.
 Notation "x < y <= z" := (x<y /\ y<=z) : bigN_scope.
 Notation "x <= y < z" := (x<=y /\ y<z) : bigN_scope.
 Notation "x <= y <= z" := (x<=y /\ y<=z) : bigN_scope.
-Notation "[ i ]" := (BigN.to_Z i) : bigN_scope.
+Notation "`[ i ]" := (BigN.to_Z i) : bigN_scope.
 Infix "mod" := BigN.modulo (at level 40, no associativity) : bigN_scope.
 
 (** Example of reasoning about [BigN] *)
@@ -110,7 +110,7 @@ case Z.eqb_spec.
 BigN.zify. auto with zarith.
 intros NEQ.
 generalize (BigN.spec_div_eucl a b).
-generalize (Z_div_mod_full [a] [b] NEQ).
+generalize (Z_div_mod_full `[a] `[b] NEQ).
 destruct BigN.div_eucl as (q,r), Z.div_eucl as (q',r').
 intros (EQ,_). injection 1 as EQr EQq.
 BigN.zify. rewrite EQr, EQq; auto.

--- a/BigQ/BigQ.v
+++ b/BigQ/BigQ.v
@@ -73,7 +73,7 @@ Notation "x < y < z" := (x<y /\ y<z) : bigQ_scope.
 Notation "x < y <= z" := (x<y /\ y<=z) : bigQ_scope.
 Notation "x <= y < z" := (x<=y /\ y<z) : bigQ_scope.
 Notation "x <= y <= z" := (x<=y /\ y<=z) : bigQ_scope.
-Notation "[ q ]" := (BigQ.to_Q q) : bigQ_scope.
+Notation "`[ q ]" := (BigQ.to_Q q) : bigQ_scope.
 
 (** [BigQ] is a ring *)
 
@@ -106,7 +106,7 @@ Lemma BigQpowerth :
  power_theory 1 BigQ.mul BigQ.eq Z.of_N BigQ.power.
 Proof.
 constructor. intros. BigQ.qify.
-replace ([r] ^ Z.of_N n)%Q with (pow_N 1 Qmult [r] n)%Q by (now destruct n).
+replace (`[r] ^ Z.of_N n)%Q with (pow_N 1 Qmult `[r] n)%Q by (now destruct n).
 destruct n. reflexivity.
 induction p; simpl; auto; rewrite ?BigQ.spec_mul, ?IHp; reflexivity.
 Qed.

--- a/BigZ/BigZ.v
+++ b/BigZ/BigZ.v
@@ -70,14 +70,14 @@ Notation "x < y < z" := (x<y /\ y<z) : bigZ_scope.
 Notation "x < y <= z" := (x<y /\ y<=z) : bigZ_scope.
 Notation "x <= y < z" := (x<=y /\ y<z) : bigZ_scope.
 Notation "x <= y <= z" := (x<=y /\ y<=z) : bigZ_scope.
-Notation "[ i ]" := (BigZ.to_Z i) : bigZ_scope.
+Notation "`[ i ]" := (BigZ.to_Z i) : bigZ_scope.
 Infix "mod" := BigZ.modulo (at level 40, no associativity) : bigZ_scope.
 Infix "÷" := BigZ.quot (at level 40, left associativity) : bigZ_scope.
 
 (** Some additional results about [BigZ] *)
 
 Theorem spec_to_Z: forall n : bigZ,
-  BigN.to_Z (BigZ.to_N n) = ((Z.sgn [n]) * [n])%Z.
+  BigN.to_Z (BigZ.to_N n) = ((Z.sgn `[n]) * `[n])%Z.
 Proof.
 intros n; case n; simpl; intros p;
   generalize (BigN.spec_pos p); case (BigN.to_Z p); auto.
@@ -86,7 +86,7 @@ intros p1 H1; case H1; auto.
 Qed.
 
 Theorem spec_to_N n:
- ([n] = Z.sgn [n] * (BigN.to_Z (BigZ.to_N n)))%Z.
+ (`[n] = Z.sgn `[n] * (BigN.to_Z (BigZ.to_N n)))%Z.
 Proof.
 case n; simpl; intros p;
   generalize (BigN.spec_pos p); case (BigN.to_Z p); auto.
@@ -94,8 +94,8 @@ intros p1 H1; case H1; auto.
 intros p1 H1; case H1; auto.
 Qed.
 
-Theorem spec_to_Z_pos: forall n, (0 <= [n])%Z ->
-  BigN.to_Z (BigZ.to_N n) = [n].
+Theorem spec_to_Z_pos: forall n, (0 <= `[n])%Z ->
+  BigN.to_Z (BigZ.to_N n) = `[n].
 Proof.
 intros n; case n; simpl; intros p;
   generalize (BigN.spec_pos p); case (BigN.to_Z p); auto.
@@ -139,7 +139,7 @@ case Z.eqb_spec.
 BigZ.zify. auto with zarith.
 intros NEQ.
 generalize (BigZ.spec_div_eucl a b).
-generalize (Z_div_mod_full [a] [b] NEQ).
+generalize (Z_div_mod_full `[a] `[b] NEQ).
 destruct BigZ.div_eucl as (q,r), Z.div_eucl as (q',r').
 intros (EQ,_). injection 1 as EQr EQq.
 BigZ.zify. rewrite EQr, EQq; auto.


### PR DESCRIPTION
To avoid conflicts with array notations, for instance, the following code was failing:

```Coq
Require Import PArray Uint63.

Check [|true; true | false|].

From Bignums Require Import BigN.

Fail Check [|true; true | false|].
(* Error: Syntax error: [term level 200] expected after '[' (in [term]). *)
```

as noticed by Quentin Canu in this Zulip thread: https://coq.zulipchat.com/#narrow/stream/237977-Coq-users/topic/Notation.20for.20Explicit.20Arrays