### PR TITLE
[CI] Remove coq-bignums before CI

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -27,25 +27,17 @@ jobs:
         with:
           opam_file: 'coq-bignums.opam'
           custom_image: ${{ matrix.image }}
-          custom_script: |
-            startGroup Print opam config
-              opam config list; opam repo list; opam list
-              echo NJOBS=${NJOBS}
-            endGroup
-            startGroup Build coq-bignums
+          install: |
+            startGroup "Install dependencies"
+              # sudo apt-get update -y -q
               opam remove -y coq-bignums # remove coq-bignums already in image
-              opam pin add -n -y -k path coq-bignums .
-              opam install -y -v -j ${NJOBS} coq-bignums
-              opam list
+              opam pin add -n -y -k path $PACKAGE $WORKDIR
+              opam update -y
+              opam install --confirm-level=unsafe-yes -j 2 $PACKAGE --deps-only
             endGroup
-            startGroup Test coq-bignums
-              git config --global --add safe.directory /github/workspace  # to avoid git clean below complaining
-              git clean -dxf .
-              make -j ${NJOBS} -C tests
-            endGroup
-            startGroup Uninstallation test
-              opam remove -y coq-bignums
-            endGroup
+          export: 'OPAMWITHTEST'
+          env:
+            OPAMWITHTEST: 'true'
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,3 +1,5 @@
+# Beware not to destroy this file when regenerating it from meta.yml
+
 name: Docker CI
 
 on:
@@ -25,9 +27,25 @@ jobs:
         with:
           opam_file: 'coq-bignums.opam'
           custom_image: ${{ matrix.image }}
-          export: 'OPAMWITHTEST'
-        env:
-          OPAMWITHTEST: 'true'
+          custom_script: |
+            startGroup Print opam config
+              opam config list; opam repo list; opam list
+              echo NJOBS=${NJOBS}
+            endGroup
+            startGroup Build coq-bignums
+              opam remove -y coq-bignums # remove coq-bignums already in image
+              opam pin add -n -y -k path coq-bignums .
+              opam install -y -v -j ${NJOBS} coq-bignums
+              opam list
+            endGroup
+            startGroup Test coq-bignums
+              git config --global --add safe.directory /github/workspace  # to avoid git clean below complaining
+              git clean -dxf .
+              make -j ${NJOBS} -C tests
+            endGroup
+            startGroup Uninstallation test
+              opam remove -y coq-bignums
+            endGroup
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -36,8 +36,8 @@ jobs:
               opam install --confirm-level=unsafe-yes -j 2 $PACKAGE --deps-only
             endGroup
           export: 'OPAMWITHTEST'
-          env:
-            OPAMWITHTEST: 'true'
+        env:
+          OPAMWITHTEST: 'true'
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/coq-bignums.opam
+++ b/coq-bignums.opam
@@ -13,10 +13,12 @@ This Coq library provides BigN, BigZ, and BigQ that used to
 be part of the standard library."""
 
 build: [make "-j%{jobs}%"]
-run-test: [make "-C" "tests" "-j%{jobs}%"]
-install: [make "install"]
+install: [
+  [make "install"]
+  [make "-C" "tests" "-j%{jobs}%"] {with-test}
+]
 depends: [
-  "ocaml" 
+  "ocaml"
   "coq" {= "dev"}
 ]
 


### PR DESCRIPTION
Otherwise the test are run with the bignums already in the Docker image rather than the one just built by the CI.

Cc @erikmd (could you check that this looks reasonnable?) @ppedrot (following https://github.com/coq-community/bignums/pull/86 )