### PR TITLE
use $(MAKE) instead of +make for recursive calls in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all: Makefile.coq
-	+make -f Makefile.coq all
+	$(MAKE) -f Makefile.coq all
 
 clean: Makefile.coq
-	+make -f Makefile.coq clean
+	$(MAKE) -f Makefile.coq clean
 	rm -f Makefile.coq Makefile.coq.conf
 
 _CoqProject:;
@@ -11,6 +11,6 @@ Makefile.coq: _CoqProject
 	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
 
 %: Makefile.coq
-	+make -f Makefile.coq $@
+	$(MAKE) -f Makefile.coq $@
 
 .PHONY: all clean


### PR DESCRIPTION
The current `Makefile` invokes hard-coded `make` command instead of `$(MAKE)`,
resulting in a failure in systems with different names for GNU make.
(In particular, the opam package coq-bignums cannot be installed on FreeBSD.)

This PR is intended to fix the problem.
