### PR TITLE
Compile without coq-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean: Makefile.coq
 _CoqProject:;
 
 Makefile.coq: _CoqProject
-	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
+	$(COQBIN)rocq makefile -f _CoqProject -o Makefile.coq
 
 %: Makefile.coq
 	$(MAKE) -f Makefile.coq $@

--- a/README.md
+++ b/README.md
@@ -62,6 +62,3 @@ cd bignums
 make   # or make -j <number-of-cores-on-your-machine> 
 make install
 ```
-
-
-

--- a/coq-bignums.opam
+++ b/coq-bignums.opam
@@ -19,7 +19,8 @@ install: [
 ]
 depends: [
   "ocaml"
-  "coq" {= "dev"}
+  "rocq-core" {= "dev"}
+  "coq-stdlib"
 ]
 
 tags: [


### PR DESCRIPTION
rocq-core and rocq-stdlib are enough